### PR TITLE
Add auto connect from modbus packet

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,85 @@
 import sys
 
-from PySide6.QtCore    import Qt
+from PySide6.QtCore    import Qt, QObject, Signal, QThread
 from PySide6.QtWidgets import QApplication, QMainWindow, QComboBox
+import serial
 import serial.tools.list_ports
 
 from ui_main import Ui_MainWindow
+
+
+class AutoConnectWorker(QObject):
+    """Поток для приёма Modbus пакета с настройками."""
+
+    finished = Signal(dict)
+    error = Signal(str)
+
+    def __init__(self, port: str):
+        super().__init__()
+        self.port = port
+        self._running = True
+
+    def stop(self):
+        self._running = False
+
+    def run(self):
+        try:
+            ser = serial.Serial(
+                self.port,
+                baudrate=9600,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=1,
+            )
+        except serial.SerialException as exc:
+            self.error.emit(str(exc))
+            return
+
+        while self._running:
+            data = ser.read(17)
+            if len(data) < 17:
+                continue
+
+            if self._check_crc(data):
+                settings = self._parse_regs(data)
+                ser.close()
+                self.finished.emit(settings)
+                return
+
+        ser.close()
+
+    # ------ вспомогательные функции ---------------------------------
+    @staticmethod
+    def _calc_crc(data: bytes) -> int:
+        crc = 0xFFFF
+        for ch in data:
+            crc ^= ch
+            for _ in range(8):
+                if crc & 1:
+                    crc >>= 1
+                    crc ^= 0xA001
+                else:
+                    crc >>= 1
+        return crc
+
+    def _check_crc(self, packet: bytes) -> bool:
+        recv = int.from_bytes(packet[-2:], byteorder="little")
+        calc = self._calc_crc(packet[:-2])
+        return recv == calc
+
+    @staticmethod
+    def _parse_regs(packet: bytes) -> dict:
+        """Возвращает настройки, извлечённые из пакета."""
+        # данные начинаются после трёх байт заголовка
+        regs = [int.from_bytes(packet[3 + i * 2 : 5 + i * 2], byteorder="big") for i in range(6)]
+        return {
+            "baud": regs[0] * 100,
+            "bits": regs[1],
+            "parity": regs[2],
+            "stop": regs[3],
+            "usart_id": regs[5],
+        }
 
 
 class UMVH(QMainWindow):
@@ -49,6 +124,10 @@ class UMVH(QMainWindow):
 
         # --- загрузка списка COM-портов ---------------------------------
         self.selected_port = None  # переменная для хранения выбранного порта
+        self.serial_config = {}
+        self.serial_port = None
+        self.worker_thread = None
+        self.worker = None
         self.populate_com_ports()
         # реагируем на смену выбора пользователем
         self.ui.comboBox_11.currentTextChanged.connect(self.on_port_selected)
@@ -59,13 +138,14 @@ class UMVH(QMainWindow):
         except AttributeError:
             self.ui.stackedWidget.setCurrentIndex(0)
 
-        self.ui.pushButton.clicked  .connect(lambda: self.switch_to(self.ui.page_2))
+        # переход в режим автоподключения
+        self.ui.pushButton.clicked.connect(self.start_auto_connect)
         self.ui.pushButton_2.clicked.connect(lambda: self.switch_to(self.ui.page_3))
 
         # кнопка "Назад" на page_3
         self.ui.pushButton_3.clicked.connect(lambda: self.switch_to(self.ui.page))
         # кнопка "Назад" на page_2
-        self.ui.pushButton_5.clicked.connect(lambda: self.switch_to(self.ui.page))
+        self.ui.pushButton_5.clicked.connect(self.stop_auto_connect)
 
     def switch_to(self, page_widget):
         self.ui.stackedWidget.setCurrentWidget(page_widget)
@@ -87,6 +167,67 @@ class UMVH(QMainWindow):
     def on_port_selected(self, port_name: str):
         """Слот сохранения выбранного пользователем порта."""
         self.selected_port = port_name
+
+    # ------------------------------------------------------------------
+    def start_auto_connect(self):
+        """Запуск автоподключения и переход на страницу ожидания."""
+        self.switch_to(self.ui.page_2)
+        if not self.selected_port:
+            return
+
+        # создаём рабочий поток для приёма пакета
+        self.worker_thread = QThread()
+        self.worker = AutoConnectWorker(self.selected_port)
+        self.worker.moveToThread(self.worker_thread)
+        self.worker_thread.started.connect(self.worker.run)
+        self.worker.finished.connect(self._auto_connect_finished)
+        self.worker.error.connect(self._auto_connect_error)
+        self.worker.finished.connect(self.worker_thread.quit)
+        self.worker_thread.start()
+
+    def _auto_connect_error(self, message: str):
+        # при ошибке просто выводим её в текстовое поле
+        self.ui.textBrowser_2.setText(message)
+
+    def _auto_connect_finished(self, settings: dict):
+        """Сохранение полученных настроек и открытие порта."""
+        self.serial_config = settings
+        # пробуем открыть порт с полученными параметрами
+        try:
+            self.serial_port = serial.Serial(
+                self.selected_port,
+                baudrate=settings["baud"],
+                bytesize=serial.EIGHTBITS if settings["bits"] == 8 else serial.SEVENBITS,
+                parity={0: serial.PARITY_NONE, 1: serial.PARITY_ODD, 2: serial.PARITY_EVEN}.get(settings["parity"], serial.PARITY_NONE),
+                stopbits=serial.STOPBITS_TWO if settings["stop"] == 2 else serial.STOPBITS_ONE,
+                timeout=1,
+            )
+        except serial.SerialException as exc:
+            self.ui.textBrowser_2.setText(str(exc))
+            return
+
+        self._fill_settings_ui()
+        self.switch_to(self.ui.page_4)
+
+    def _fill_settings_ui(self):
+        """Заполняем виджеты на page_4 полученными значениями."""
+        cfg = self.serial_config
+        self.ui.comboBox_5.setCurrentText(str(cfg.get("baud", "")))
+        self.ui.comboBox_6.setCurrentText(str(cfg.get("bits", "")))
+        parity_idx = {0: 0, 1: 1, 2: 2}.get(cfg.get("parity"), 0)
+        self.ui.comboBox_7.setCurrentIndex(parity_idx)
+        self.ui.comboBox_8.setCurrentText(str(cfg.get("stop", "")))
+        if "usart_id" in cfg:
+            self.ui.spinBox_2.setValue(cfg["usart_id"])
+
+    def stop_auto_connect(self):
+        """Останавливаем поток автоподключения и возвращаемся на главную."""
+        if self.worker:
+            self.worker.stop()
+        if self.worker_thread:
+            self.worker_thread.quit()
+            self.worker_thread.wait()
+        self.switch_to(self.ui.page)
 
 
 def main():


### PR DESCRIPTION
## Summary
- listen on selected COM port when entering auto connect page
- parse incoming Modbus packet with UART settings and open the port
- fill widgets on page_4 with received parameters
- allow stopping the auto connect thread when returning to main page

## Testing
- `python3 -m py_compile main.py ui_main.py myicon.py`

------
https://chatgpt.com/codex/tasks/task_e_688205a88834832ab31a98923d1e6204