### PR TITLE
Fix bootloader update completion

### DIFF
--- a/main.py
+++ b/main.py
@@ -801,8 +801,10 @@ class UMVH(QMainWindow):
             self.boot_thread.wait()
 
         if success:
-            self.ui.stackedWidget_3.setCurrentWidget(self.ui.page_12)
-            QTimer.singleShot(5000, self._boot_finish_success)
+            # при успешном обновлении
+            # сразу возвращаем интерфейс
+            # в исходное состояние
+            self._boot_finish_success()
         else:
             self.ui.stackedWidget_3.setCurrentWidget(self.ui.page_13)
             QTimer.singleShot(5000, self._boot_finish_failure)


### PR DESCRIPTION
## Summary
- return to the main page immediately after a successful bootloader update

## Testing
- `python -m py_compile main.py ui_main.py myicon.py`

------
https://chatgpt.com/codex/tasks/task_e_6889d1ba39a4832aa7cc70a768965f77