### PR TITLE
Ensure calibration register sent before password

### DIFF
--- a/main.py
+++ b/main.py
@@ -1091,6 +1091,10 @@ class UMVH(QMainWindow):
             except ValueError:
                 pass
 
+        if REG_PASSWORD in regs and REG_PORT_SENSOR_BIND not in regs:
+            # пароль должен сопровождаться актуальными параметрами режима и датчика
+            regs[REG_PORT_SENSOR_BIND] = self._compose_calibration_register()
+
         order = [
             REG_PORT_SENSOR_BIND,
             REG_CAL_POINT_X1,


### PR DESCRIPTION
## Summary
- ensure the calibration register is sent alongside password updates when only the password changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd04e1f260832a86cd2e322ce5ba69